### PR TITLE
Collapse long comments with only CSS

### DIFF
--- a/static/js.js
+++ b/static/js.js
@@ -485,18 +485,6 @@ function submitUUID(type) {
     window.location.href = "/web/fixes/submit/" + uuid + "/" + type
 }
 
-function collapseLongComments() {
-    let comments = document.getElementsByClassName("comment-body")
-
-    for (let i = 0; i < comments.length; i++) {
-        if (comments[i].innerHTML.length > 2000) {
-            comments[i].parentElement.parentElement.style.height = "600px"
-            comments[i].parentElement.parentElement.style.overflow = "scroll"
-            comments[i].parentElement.parentElement.style.overflowX = "hidden"
-        }
-    }
-}
-
 function enableDarkMode() {
     document.getElementsByTagName("head")[0].insertAdjacentHTML(
         "beforeend",

--- a/static/styles.css
+++ b/static/styles.css
@@ -49,6 +49,9 @@ body {
 
 .comment {
     border: 1px solid #cbcbcb;
+    max-height: 600px;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 .comment-header {

--- a/templates/submission.gohtml
+++ b/templates/submission.gohtml
@@ -323,7 +323,6 @@
         <br>
 
         <script>linkIDsInComments()</script>
-        <script>collapseLongComments()</script>
 
         {{template "view-submission-nav" .}}
 


### PR DESCRIPTION
Better and simpler way of collapsing comments, fixes comment height being calculated incorrectly in some cases. Example: [submission 15179](https://fpfss.unstable.life/web/submission/15179)