### PR TITLE
Better word wrap for meta fields

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -269,7 +269,7 @@ textarea {
 }
 
 .break-all {
-    word-break: break-all;
+    word-break: break-word;
 }
 
 #table-wrapper {


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/71368227/167599809-c493a3c3-8b79-4d67-abbe-b03ab5c391f3.png)

**After:**
![image](https://user-images.githubusercontent.com/71368227/167600015-6b4338d1-5dc6-43a0-907c-07b4018f3a87.png)

